### PR TITLE
Update elm.json for 0.19 beta

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -9,8 +9,8 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "elm-lang/core": "6.0.0 <= v < 7.0.0",
-        "elm-lang/http": "2.0.0 <= v < 3.0.0"
+        "elm/core": "1.0.0 <= v < 2.0.0",
+        "elm/http": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {}
 }

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "krisajenkins/remotedata",
     "summary": "Tools for fetching data from remote sources (incl. HTTP).",
     "license": "MIT",
-    "version": "4.5.0",
+    "version": "5.0.0",
     "exposed-modules": [
         "RemoteData"
     ],

--- a/test/elm.json
+++ b/test/elm.json
@@ -1,4 +1,5 @@
 {
+    "type": "application",
     "version": "2.2.1",
     "summary": "Tools for fetching data from remote sources (incl. HTTP).",
     "repository": "https://github.com/krisajenkins/remotedata.git",
@@ -11,9 +12,11 @@
         "RemoteData"
     ],
     "dependencies": {
-        "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "elm-lang/http": "1.0.0 <= v < 2.0.0",
-        "rtfeldman/legacy-elm-test": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "6.0.0",
+        "elm-lang/http": "2.0.0",
+        "rtfeldman/legacy-elm-test": "4.0.0"
     },
-    "elm-version": "0.18.0 <= v < 0.19.0"
+    "test-dependencies": {
+    },
+    "elm-version": "0.19.0"
 }

--- a/test/elm.json
+++ b/test/elm.json
@@ -12,8 +12,8 @@
         "RemoteData"
     ],
     "dependencies": {
-        "elm-lang/core": "6.0.0",
-        "elm-lang/http": "2.0.0",
+        "elm/core": "1.0.0",
+        "elm/http": "1.0.0",
         "rtfeldman/legacy-elm-test": "4.0.0"
     },
     "test-dependencies": {


### PR DESCRIPTION
New binaries were released yesterday, and the `elm-lang/*` packages were moved to `elm/*`. 
These dependencies are compatible with the new binaries.